### PR TITLE
feat : added simulation construct and Transformation util

### DIFF
--- a/src/sim/DomainDescriptors.jl
+++ b/src/sim/DomainDescriptors.jl
@@ -1,0 +1,122 @@
+# DomainDescriptors
+
+module DomainDescriptors
+
+#=
+Packages
+=#
+
+#=
+Public API
+=#
+
+export DomainDescriptor
+
+#=
+Domain Descriptor
+=#
+
+struct DomainDescriptor{T<:AbstractFloat}
+
+    # Mesh Size
+    nx::Int64
+    ny::Int64
+    ny_F::Int64
+    nz::Int64
+
+    # Domain Length
+    Lx::T
+    Ly::T
+    Lz::T
+
+    # Grid Step
+    dx::T
+    dz::T
+
+    # Grid Definition
+    x::Vector{T}
+    z::Vector{T}
+    y::Vector{T}
+    y_F::Vector{T}
+
+    # Finite Difference Grid
+    dy::Vector{T}
+    dy_F::Vector{T}
+
+    function DomainDescriptor{T}(nx::Int64, ny::Int64, nz::Int64, Lx::T, Ly::T, Lz::T) where {T<:AbstractFloat}
+
+        function define_grid!(domain::DomainDescriptor)
+
+            # Periodic Direction
+            domain.x[:] = range(start=0.0, stop=domain.Lx, step=domain.dx)[1:end-1]
+            domain.z[:] = range(start=0.0, stop=domain.Lz, step=domain.dz)[1:end-1]
+
+            # Wall-Normal Direction (Base Grid)
+            for i in eachindex(domain.y)
+                domain.y[domain.ny-(i-1)] = cospi((i - 1) / (domain.ny - 1))
+            end
+
+            # Wall-Normal Direction (Fractional Grid)
+            for i = 2:domain.ny_F-1
+                domain.y_F[i] = 0.5 * (domain.y[i] + domain.y[i-1])
+            end
+
+            domain.y_F[1] = 2 * domain.y[1] - domain.y_F[2]
+            domain.y_F[end] = 2 * domain.y[end] - domain.y_F[end-1]
+
+            # Machine Precision Centerline
+            if (mod(domain.ny, 2) != 0)
+                domain.y[Int64((domain.ny + 1) / 2)] = 0.0
+            end
+
+            if (mod(domain.ny_F, 2) != 0)
+                domain.y_F[Int64((domain.ny_F + 1) / 2)] = 0.0
+            end
+
+            # Finite Difference Scaling
+            for i = 1:(domain.ny-1)
+                domain.dy[i] = (domain.y[i+1] - domain.y[i])
+            end
+
+            for i = 1:(domain.ny_F-1)
+                domain.dy_F[i] = (domain.y_F[i+1] - domain.y_F[i])
+            end
+
+            @info("Wall-normal grid definition completed.")
+
+            return nothing
+
+        end
+
+        @info("--- Initialising DomainDescriptor ---")
+
+        # Grid
+        ny_F::Int64 = ny + 1
+
+        x::Vector{T} = Vector{T}(undef, nx)
+        z::Vector{T} = Vector{T}(undef, nz)
+        y::Vector{T} = Vector{T}(undef, ny)
+        y_F::Vector{T} = Vector{T}(undef, ny_F)
+        dy::Vector{T} = Vector{T}(undef, ny - 1)
+        dy_F::Vector{T} = Vector{T}(undef, ny_F - 1)
+
+        # Grid Size
+        dx::T = Lx / nx
+        dz::T = Lz / nz
+
+        # Initialise
+        domain::DomainDescriptor = new{T}(nx, ny, ny_F, nz, Lx, Ly, Lz, dx, dz, x, z, y, y_F, dy, dy_F)
+
+        # Define Grid
+        define_grid!(domain)
+
+        @info("--- DomainDescriptor initialised ---")
+        @info(" ")
+
+        return domain
+
+    end
+
+end
+
+end

--- a/src/sim/States.jl
+++ b/src/sim/States.jl
@@ -1,0 +1,75 @@
+# State
+
+module States
+
+#=
+Packages
+=#
+
+#=
+Public API
+=#
+
+export State
+
+#=
+State
+=#
+
+mutable struct State{T<:AbstractFloat}
+
+    # Simulation Time
+    t_sim::T # Current Time
+    T_sim::T # Total Time
+    nt::Int64 # Current Time Step
+
+    # Velocity-Pressure State
+    u::Array{Complex{T},3}
+    v::Array{Complex{T},3}
+    v_F::Array{Complex{T},3}
+    w::Array{Complex{T},3}
+    p::Array{Complex{T},3}
+    fourier_mode::Bool
+    frac_mode::Bool
+
+    # Statistical State
+    n_sample::Int64
+    u_bar::Vector{T}
+    v_bar::Vector{T}
+    w_bar::Vector{T}
+    uu_bar::Vector{T}
+    uv_bar::Vector{T}
+    uw_bar::Vector{T}
+    vv_bar::Vector{T}
+    vw_bar::Vector{T}
+    ww_bar::Vector{T}
+
+    # Flow Attribute
+    dp0_dx::T # Mean Pressure Gradient
+    u_bulk::T # Bulk Velocity
+    u_tau_upr::T # Upper Wall Shear Stress
+    u_tau_lwr::T # Lower Wall Shear Stress
+
+    function State{T}(T_sim::T, nx::Int64, ny::Int64, nz::Int64) where {T<:AbstractFloat}
+
+        @info("--- Initialising State ---")
+        @info("--- State initialised ---")
+        @info(" ")
+
+        return new{T}(0.0, T_sim, 0,
+            zeros(Complex{T}, (ny, nx, nz)), # Velocity-Pressure State
+            zeros(Complex{T}, (ny, nx, nz)),
+            zeros(Complex{T}, (ny + 1, nx, nz)),
+            zeros(Complex{T}, (ny, nx, nz)),
+            zeros(Complex{T}, (ny, nx, nz)),
+            false, false,
+            0, # Statistical State
+            zeros(T, (ny)), zeros(T, (ny)), zeros(T, (ny)),
+            zeros(T, (ny)), zeros(T, (ny)), zeros(T, (ny)), zeros(T, (ny)), zeros(T, (ny)), zeros(T, (ny)),
+            0.0, 0.0, 0.0, 0.0) # Flow Attribute
+
+    end
+
+end
+
+end

--- a/src/util/Transformations.jl
+++ b/src/util/Transformations.jl
@@ -1,0 +1,307 @@
+# Transformations
+
+module Transformations
+
+#=
+Package
+=#
+
+using FFTW
+
+using ..States: State
+using ..DomainDescriptors: DomainDescriptor
+
+#=
+Public API
+=#
+
+export Transformer
+export y2y_F!, y_F2y!
+export physical2fourier!, fourier2physical!
+
+#=
+Transformer
+=#
+
+# FFTW Wisdom Flag
+wisdom_dict::Dict{String,UInt32} = Dict()
+
+wisdom_dict["estimate"] = FFTW.ESTIMATE
+wisdom_dict["measure"] = FFTW.MEASURE
+wisdom_dict["patient"] = FFTW.PATIENT
+wisdom_dict["exhaustive"] = FFTW.EXHAUSTIVE
+
+struct Transformer{T<:AbstractFloat}
+
+    # FFTW Plan (Base Grid)
+    fft_plan
+    ifft_plan
+
+    # FFTW Plan (Fractional Grid)
+    fft_plan_F
+    ifft_plan_F
+
+    # FFTW Frequency
+    freq_kx::Vector{T}
+    freq_kz::Vector{T}
+
+    # De-aliasing Frequency Bound
+    freq_kx_max::T
+    freq_kz_max::T
+
+    function Transformer{T}(dir_wisdom::String, state::State{T}, domain::DomainDescriptor; wisdom_flag::String="measure", reset_wisdom::Bool=false) where {T<:AbstractFloat}
+
+        @info("--- Initialising Transformer ---")
+
+        # Directory Check
+        if (!isdir(dir_wisdom))
+            mkdir(dir_wisdom)
+        end
+
+        if (isfile(string(dir_wisdom, "/fft"))) && (!reset_wisdom)
+            @info("Loading FFTW wisdom from $(dir_wisdom).")
+            FFTW.import_wisdom(string(dir_wisdom, "/fft"))
+        end
+
+        @info("Initiating FFTW wisdom planning.")
+
+        # Planning
+        @time begin
+
+            fft_plan = plan_fft!(state.u, (2, 3); flags=wisdom_dict[wisdom_flag])
+            ifft_plan = plan_bfft!(state.u, (2, 3); flags=wisdom_dict[wisdom_flag])
+
+            fft_plan_F = plan_fft!(state.v_F, (2, 3); flags=wisdom_dict[wisdom_flag])
+            ifft_plan_F = plan_bfft!(state.v_F, (2, 3); flags=wisdom_dict[wisdom_flag])
+
+        end
+
+        FFTW.export_wisdom(string(dir_wisdom, "/fft"))
+
+        @info("FFTW wisdom planning complete.")
+
+        # Frequency
+        n::Int64 = size(state.u, 2)
+        freq_kx::Vector{T} = fftfreq(n) * n * (2pi / domain.Lx)
+        freq_kx_max::T = floor(n / 3) * (2pi / domain.Lx)
+
+        n = size(state.u, 3)
+        freq_kz::Vector{T} = fftfreq(n) * n * (2pi / domain.Lz)
+        freq_kz_max::T = floor(n / 3) * (2pi / domain.Lz)
+
+        @info("--- Transformer initialised ---")
+        @info(" ")
+
+        return new{T}(fft_plan, ifft_plan, fft_plan_F, ifft_plan_F, freq_kx, freq_kz, freq_kx_max, freq_kz_max)
+
+    end
+
+end
+
+#=
+FFT Transformation
+=#
+
+function physical2fourier!(tf::Transformer{T}, state::State{T}) where {T<:AbstractFloat}
+
+    # Mode Check
+    if (state.fourier_mode)
+        @debug("Applying a physical2fourier! fftw transformation when fourier_mode = $(state.fourier_mode).")
+        return
+    end
+
+    # FFT
+    tf.fft_plan * state.u
+    tf.fft_plan * state.v
+    tf.fft_plan * state.w
+    tf.fft_plan * state.p
+
+    tf.fft_plan_F * state.v_F
+
+    # Grid Sizing
+    ny::Int64, nx::Int64, nz::Int64 = size(state.u)
+
+    # Normalisation
+    n::T = prod(size(state.u)[2:3])
+
+    state.u[:] ./= n
+    state.v[:] ./= n
+    state.w[:] ./= n
+    state.p[:] ./= n
+
+    state.v_F[:] ./= n
+
+    # Update Mode
+    state.fourier_mode = true
+
+    return nothing
+
+end
+
+function physical2fourier!(tf::Transformer{T}, arr::Array{Complex{T},3}, frac_mode::Bool, dealias_mode::Bool) where {T<:AbstractFloat}
+
+    # FFT
+    if (frac_mode)
+
+        tf.fft_plan_F * arr
+
+    else
+
+        tf.fft_plan * arr
+
+    end
+
+    # Grid Sizing
+    ny::Int64, nx::Int64, nz::Int64 = size(arr)
+
+    # De-aliasing
+    if (dealias_mode)
+        for ix = 1:nx
+
+            if (abs(tf.freq_kx[ix]) > tf.freq_kx_max)
+
+                arr[:, ix, :] .= 0.0 + 0.0im
+
+            end
+
+        end
+
+        for iz = 1:nz
+
+            if (abs(tf.freq_kz[iz]) > tf.freq_kz_max)
+
+                arr[:, :, iz] .= 0.0 + 0.0im
+
+            end
+
+        end
+    end
+
+    # Normalisation
+    n::T = prod(size(arr)[2:3])
+
+    arr[:] ./= n
+
+    return nothing
+
+end
+
+function fourier2physical!(tf::Transformer{T}, state::State{T}) where {T<:AbstractFloat}
+
+    # Mode Check
+    if (!state.fourier_mode)
+        @debug("Applying a fourier2physical! fftw transformation when fourier_mode = $(state.fourier_mode).")
+        return
+    end
+
+    # IFFT
+    tf.ifft_plan * state.u
+    tf.ifft_plan * state.v
+    tf.ifft_plan * state.w
+    tf.ifft_plan * state.p
+
+    tf.ifft_plan_F * state.v_F
+
+    # Update Mode
+    state.fourier_mode = false
+
+    state.u[:] = real(state.u[:])
+    state.v[:] = real(state.v[:])
+    state.w[:] = real(state.w[:])
+    state.p[:] = real(state.p[:])
+
+    state.v_F[:] = real(state.v_F[:])
+
+    return nothing
+
+end
+
+function fourier2physical!(tf::Transformer{T}, arr::Array{Complex{T},3}, frac_mode::Bool) where {T<:AbstractFloat}
+
+    # IFFT
+    if (frac_mode)
+
+        tf.ifft_plan_F * arr
+
+    else
+
+        tf.ifft_plan * arr
+
+    end
+
+    arr[:] = real(arr[:])
+
+    return nothing
+
+end
+
+#=
+Grid Transformation
+=#
+
+function y2y_F!(state::State{T}) where {T<:AbstractFloat}
+
+    if (state.frac_mode)
+        @debug("Applying a y2y_F! grid transformation when frac_mode = $(state.frac_mode).")
+        return
+    end
+
+    # Array
+    arr = state.v
+    arr_F = state.v_F
+
+    # Sizing
+    ny_F::Int64 = size(arr_F, 1)
+
+    # Transformation
+    arr_F[1, :, :] .= arr[1, :, :]
+    arr_F[end, :, :] .= arr[end, :, :]
+
+    for iy = 2:ny_F-1
+
+        arr_F[iy, :, :] .= 0.5 * (arr[iy, :, :] + arr[iy-1, :, :])
+
+    end
+
+    # Swap Mode
+    state.frac_mode = true
+
+    return nothing
+
+end
+
+function y_F2y!(state::State)
+
+    if (!state.frac_mode)
+        @debug("Applying a y_F2y! grid transformation when frac_mode = $(state.frac_mode).")
+        return
+    end
+
+    # Array
+    arr = state.v
+    arr_F = state.v_F
+
+    # Sizing
+    n::NTuple{3,Int64} = size(arr)
+
+    ny::Int64 = n[1]
+
+    # Enforce Boundary Condition
+    arr[1, :, :] .= arr_F[1, :, :]
+    arr[end, :, :] .= arr_F[end, :, :]
+
+    # Transformation Loop
+    for iy = 2:ny-1
+
+        arr[iy, :, :] = 2 * arr_F[iy, :, :] - arr[iy-1, :, :]
+
+    end
+
+    # Switch Mode
+    state.frac_mode = false
+
+    return nothing
+
+end
+
+end


### PR DESCRIPTION
Added the minimal code to kick start discussion on documentation and testing.

Code consist of two simulation construct - States and DomainDescriptors - and a utility construct - Transformations.

States: Contains the majority of the simulation data that is being mutated as the simulation is carried out, defined in a Julia struct.

DomainDescriptors: Contains data on the spatial description of the simulation box, and the related finite difference grid discretisation, defined in a Julia struct.

Transformations: Contains a Julia struct and functions related to FFTW and a grid interpolation scheme required for the simulation. Wraps around the FFTW library.

In the first meetup, we discussed about linting and formatting. The commits here are formatted with the VSCode for Julia integrated formatter.